### PR TITLE
LCD: Use `.nearest` filter for screen

### DIFF
--- a/src/gameboy/lcd.v
+++ b/src/gameboy/lcd.v
@@ -18,7 +18,7 @@ fn (mut g Gameboy) init_gg() {
 		window_title: 'gamevoy'
 		init_fn: fn (mut g Gameboy) {
 			if mut gg_ctx := g.gg {
-				g.image_idx = gg_ctx.new_streaming_image(160, 144, 4, pixel_format: .rgba8)
+				g.image_idx = gg_ctx.new_streaming_image(160, 144, 4, pixel_format: .rgba8, min_filter: .nearest, mag_filter: .nearest)
 			}
 		}
 		frame_fn: fn (mut g Gameboy) {


### PR DESCRIPTION
Maybe it's better to make this an option in the program itself?

## Before: 
![image](https://github.com/lemoncmd/gamevoy/assets/44401509/bc2942ff-f07a-472d-9067-d43d4681eba6)

## After:
![image](https://github.com/lemoncmd/gamevoy/assets/44401509/6ad2a7d1-7666-4bc9-8bc6-3158a6e8ffb0)

